### PR TITLE
General documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Login via Azure CLI:
 az login
 ```
 
+Note: If you get a PermissionDenied error about `listSecrets` when the app tries to read AI Project connection secrets, ensure your Azure identity has the **Azure AI Developer** or **Cognitive Services User** role (or use a service principal with equivalent permissions). See https://aka.ms/FoundryPermissions for details.
 
 Copy the environment template and populate with your Azure credentials:
 
@@ -274,7 +275,8 @@ The application uses environment variables for configuration. Copy `app/env_samp
 | `AI_SEARCH_TYPE` | Search type for document queries | `SIMPLE` |
 | `GRAPH_QUERY_TYPE` | GraphRAG query method | `local` |
 | `AI_SEARCH_INDEX_NAME` | Azure AI Search index name | `report_agent` |
-| `AI_SEARCH_CONNECTION_NAME` | Azure AI Search Connection Name in AI Foundry | `agentbing` |
+| `AI_SEARCH_CONNECTION_NAME` | Azure AI Search Connection Name in AI Foundry | `agentsearcher` |
+| `BING_CONNECTION_NAME` | Bing Grounding Connection Name in AI Foundry | `agentbing` |
 | `INPUT_DIR` | Directory with GraphRAG output files | `./data/output` |
 | `RAW_INPUT_PATH` | Path to raw input documents | `/path/to/raw/data` |
 | `OUTPUT_PATH` | Path for processed documents | `/path/to/processed/data` |

--- a/app/env_sample
+++ b/app/env_sample
@@ -16,7 +16,7 @@ AI_SEARCH_INDEX_NAME=apple_report_agent
 RAW_INPUT_PATH=/Users/shanepeckham/sources/data/apple/extracted_text
 OUTPUT_PATH=/Users/shanepeckham/sources/data/apple/processed_text
 GRAPH_OUTPUT_PATH=/Users/shanepeckham/sources/data/apple/graph_output/
-INPUT_DIR=./apple/output
+INPUT_DIR=./data/output
 TEAM_NAME=cr_team
 
 # Azure CLI Authentication (Optional - choose one method)


### PR DESCRIPTION
**Documentation improvements:**
* Added a note to the `README.md` explaining the need for the **Azure AI Developer** or **Cognitive Services User** role (or equivalent permissions) when accessing AI Project connection secrets, with a link to further details.

**Environment variable updates:**
* Changed the value of `AI_SEARCH_CONNECTION_NAME` in the environment variable documentation to `agentsearcher`, and introduced a new variable `BING_CONNECTION_NAME` for Bing Grounding connections.
* Updated the sample environment file (`app/env_sample`) to use a more generic output directory path for `INPUT_DIR`.